### PR TITLE
Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM python:3.6-slim-stretch
+
+ENV PIP_NO_CACHE_DIR 1
+
+# Pypi package Repo upgrade
+RUN pip3 install --upgrade pip setuptools
+
+# copy the dependencies file to the working directory
+COPY requirements.txt .
+
+# install dependencies
+RUN pip install -r requirements.txt
+
+# copy the content of the local src directory to the working directory
+COPY . .
+
+# Starting Worker
+CMD ["python3","-m","tgfilestream"]
+
+EXPOSE 8080

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6-slim-stretch
+FROM python:3.8.6-slim-buster
 
 ENV PIP_NO_CACHE_DIR 1
 

--- a/tgfilestream/paralleltransfer.py
+++ b/tgfilestream/paralleltransfer.py
@@ -160,10 +160,10 @@ class ParallelTransferrer:
                             last_part_cut: int) -> AsyncGenerator[bytes, None]:
         log = self.log
         try:
-            part = first_part
             dcm = self.dc_managers[dc_id]
             async with dcm.get_connection() as conn:
                 log = conn.log
+                part = first_part
                 while part <= last_part:
                     result = await conn.sender.send(request)
                     request.offset += part_size


### PR DESCRIPTION
- added `Dockerfile`. users can build a docker image using `docker build --tag tgfilestream:latest .` on a vps or there machine
- seems like async had issues with 3.6 so updated to `python3.8-slimbuster`